### PR TITLE
jszip 3.1.5 license clarification

### DIFF
--- a/curations/npm/npmjs/-/jszip.yaml
+++ b/curations/npm/npmjs/-/jszip.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: jszip
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.5:
+    files:
+      - license: ''
+        path: package/README.markdown
+      - license: GPL-3.0-only OR MIT
+        path: package/package.json
+      - attributions:
+          - Copyright (c) 2007 Free Software Foundation, Inc. http://fsf.org/
+          - Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso
+        license: GPL-3.0-only OR MIT
+        path: package/LICENSE.markdown


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jszip 3.1.5 license clarification

**Details:**
Add/clarify license information and attributions for jszip 3.1.5

**Resolution:**
https://github.com/Stuk/jszip

**Affected definitions**:
- [jszip 3.1.5](https://clearlydefined.io/definitions/npm/npmjs/-/jszip/3.1.5)